### PR TITLE
Fix issue #5 on branch core-api-v1

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.
 
-- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+- Create a new plugin or clone an existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
 
 - Install dependencies
 ```sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v 0.1.4
+- fix issue #5 : when code call raises an exception, the error is logged and the event is tagged '_aggregateexception'. It avoids logstash crash.
+
 # v 0.1.3
 - break compatibility with logstash 1.4
 - remove "milestone" method call which is deprecated in logstash 1.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logstash Filter Aggregate Documentation
 
-The aim of this filter is to aggregate informations available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event.
+The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event.
  
 ## Example #1
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ it allows to initialize 'sql_duration' map entry to 0 only if this map entry is 
 - after the final event, the map attached to task is deleted
 - in one filter configuration, it is recommanded to define a timeout option to protect the filter against unterminated tasks. It tells the filter to delete expired maps
 - if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted
+- finally, if `code` execution raises an exception, the error is logged and event is tagged '_aggregateexception'
 
 ## Aggregate Plugin Options
 - **task_id :**  

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -5,7 +5,7 @@ require "logstash/namespace"
 require "thread"
 
 #
-# The aim of this filter is to aggregate informations available among several events (typically log lines) belonging to a same task,
+# The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task,
 # and finally push aggregated information into final task event.
 # 
 # ==== Example #1
@@ -103,8 +103,7 @@ require "thread"
 # ----------------------------------
 #
 # * the final event is exactly the same than example #1
-# * the key point is the "||=" ruby operator. +
-# it allows to initialize 'sql_duration' map entry to 0 only if this map entry is not already initialized
+# * the key point is the "||=" ruby operator. It allows to initialize 'sql_duration' map entry to 0 only if this map entry is not already initialized
 #
 #
 # ==== How it works
@@ -121,29 +120,39 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 
 	config_name "aggregate"
 
-	# The expression defining task ID to correlate logs. +
-	# This value must uniquely identify the task in the system +
-	# Example value : "%{application}%{my_task_id}" +
+	# The expression defining task ID to correlate logs.
+	#
+	# This value must uniquely identify the task in the system.
+	#
+	# Example value : "%{application}%{my_task_id}"
 	config :task_id, :validate => :string, :required => true
 
-	# The code to execute to update map, using current event. +
-	# Or on the contrary, the code to execute to update event, using current map. +
-	# You will have a 'map' variable and an 'event' variable available (that is the event itself). +
-	# Example value : "map['sql_duration'] += event['duration']" +
+	# The code to execute to update map, using current event.
+	#
+	# Or on the contrary, the code to execute to update event, using current map.
+	#
+	# You will have a 'map' variable and an 'event' variable available (that is the event itself).
+	#
+	# Example value : "map['sql_duration'] += event['duration']"
 	config :code, :validate => :string, :required => true
 
-	# Tell the filter what to do with aggregate map (default :  "create_or_update"). +
-	# create: create the map, and execute the code only if map wasn't created before +
-	# update: doesn't create the map, and execute the code only if map was created before +
-	# create_or_update: create the map if it wasn't created before, execute the code in all cases +
+	# Tell the filter what to do with aggregate map (default :  "create_or_update").
+	#
+	# create: create the map, and execute the code only if map wasn't created before
+	#
+	# update: doesn't create the map, and execute the code only if map was created before
+	#
+	# create_or_update: create the map if it wasn't created before, execute the code in all cases
 	config :map_action, :validate => :string, :default => "create_or_update"
 
 	# Tell the filter that task is ended, and therefore, to delete map after code execution.  
 	config :end_of_task, :validate => :boolean, :default => false
 
-	# The amount of seconds after a task "end event" can be considered lost. +
-	# The task "map" is evicted. +
-	# The default value is 0, which means no timeout so no auto eviction. +
+	# The amount of seconds after a task "end event" can be considered lost.
+	#
+	# The task "map" is evicted.
+	#
+	# The default value is 0, which means no timeout so no auto eviction.
 	config :timeout, :validate => :number, :required => false, :default => 0
 
 	

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -219,7 +219,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 			begin
 				@codeblock.call(event, map)
 				noError = true
-			rescue Exception => exception
+			rescue => exception
 				@logger.error("Aggregate exception occurred. Error: #{exception} ; Code: #{@code} ; Map: #{map} ; EventData: #{event.instance_variable_get('@data')}")
 				event.tag("_aggregateexception")
 			end

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -114,6 +114,7 @@ require "thread"
 # * after the final event, the map attached to task is deleted
 # * in one filter configuration, it is recommanded to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
 # * if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted
+# * finally, if `code` execution raises an exception, the error is logged and event is tagged '_aggregateexception'
 #
 #
 class LogStash::Filters::Aggregate < LogStash::Filters::Base
@@ -136,13 +137,13 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 	# Example value : "map['sql_duration'] += event['duration']"
 	config :code, :validate => :string, :required => true
 
-	# Tell the filter what to do with aggregate map (default :  "create_or_update").
+	# Tell the filter what to do with aggregate map.
 	#
-	# create: create the map, and execute the code only if map wasn't created before
+	# `create`: create the map, and execute the code only if map wasn't created before
 	#
-	# update: doesn't create the map, and execute the code only if map was created before
+	# `update`: doesn't create the map, and execute the code only if map was created before
 	#
-	# create_or_update: create the map if it wasn't created before, execute the code in all cases
+	# `create_or_update`: create the map if it wasn't created before, execute the code in all cases
 	config :map_action, :validate => :string, :default => "create_or_update"
 
 	# Tell the filter that task is ended, and therefore, to delete map after code execution.  
@@ -152,7 +153,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 	#
 	# The task "map" is evicted.
 	#
-	# The default value is 0, which means no timeout so no auto eviction.
+	# Default value (`0`) means no timeout so no auto eviction.
 	config :timeout, :validate => :number, :required => false, :default => 0
 
 	

--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
   s.version         = '0.1.3'
   s.licenses = ['Apache License (2.0)']
-  s.summary = "The aim of this filter is to aggregate informations available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event."
+  s.summary = "The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors = ["Elastic", "Fabien Baligand"]
   s.email = 'info@elastic.co'

--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
-  s.version         = '0.1.3'
+  s.version         = '0.1.4'
   s.licenses = ['Apache License (2.0)']
   s.summary = "The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -96,7 +96,7 @@ describe LogStash::Filters::Aggregate do
 				end
 
 				describe "and the same id of the 'start event'" do
-					it "add 'sql_duration' field to the end event and deletes the recorded 'start event'" do
+					it "add 'sql_duration' field to the end event and deletes the aggregate map associated to taskid" do
 						expect(aggregate_maps.size).to eq(1)
 
 						@update_filter.filter(update_event("taskid" => @task_id_value, "duration" => 2))
@@ -110,6 +110,16 @@ describe LogStash::Filters::Aggregate do
 
 				end
 			end
+		end
+	end
+
+	context "Event which causes an exception when code call" do
+		it "intercepts exception, logs the error and tags the event with '_aggregateexception'" do
+			@start_filter = setup_filter({ "code" => "fail 'Test'" })
+			start_event = start_event("taskid" => "id124")
+			@start_filter.filter(start_event)
+
+			expect(start_event["tags"]).to eq(["_aggregateexception"])
 		end
 	end
 


### PR DESCRIPTION
Fix issue #5.
When code call raises an exception, the error is logged and the event is tagged '_aggregateexception'.
Thus, it avoids logstash crash.