### PR TITLE
Fix(Gemfile): Allow installation in logstash 2.0.0

### DIFF
--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses = ['Apache License (2.0)']
   s.summary = "The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
   s.add_development_dependency 'logstash-devutils', '~> 0'
 end


### PR DESCRIPTION
Hi *,
we noticed that the plugin is failing in logstash 2.0.0. We'd propose this fix. Please apply if it's useful :)

Fixes error:
logstash-filter-aggregate (>= 0) java depends on
...  logstash-core (< 3.0.0, >= 2.0.0.beta2) java