### PR TITLE
Use filter workers == 1 otherwise aggregations inacurate

### DIFF
--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -7,6 +7,8 @@ require "thread"
 # 
 # The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task,
 # and finally push aggregated information into final task event.
+# You should be very careful to set logstash filter workers to 1 for this filter to work correctly otherwise documents
+# may be processed out of sequence and unexpected results will occur.
 # 
 # ==== Example #1
 # 


### PR DESCRIPTION
In tests when not setting `-w 1` when starting logstash, I got some events out of sequence, and hence inaccurate aggregations.