### PR TITLE
new feature: add new option 'aggregate_maps_path'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+ - new feature: add new option "aggregate_maps_path" so that aggregate maps can be stored at logstash shutdown and reloaded at logstash startup
+
 ## 2.0.5
  - internal,deps: Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,14 @@ Default value: `false`
 
 - **timeout:**  
 The amount of seconds after a task "end event" can be considered lost.  
-The task "map" is then evicted.  
+When timeout occurs for a task, The task "map" is evicted.  
 The default value is 0, which means no timeout so no auto eviction.  
+
+- **aggregate_maps_path:**  
+The path to file where aggregate maps are stored when logstash stops and are loaded from when logstash starts.  
+If not defined, aggregate maps will not be stored at logstash stop and will be lost.   
+Should be defined for only one aggregate filter (as aggregate maps are global).  
+Example value : `"/path/to/.aggregate_maps"`
 
 
 ## Need Help?

--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
-  s.version         = '2.0.5'
+  s.version         = '2.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -182,4 +182,29 @@ describe LogStash::Filters::Aggregate do
 
   end
 
+  context "aggregate_maps_path option is defined, " do
+    describe "close event append then register event append, " do
+      it "stores aggregate maps to configured file and then loads aggregate maps from file" do
+        
+        store_file = "aggregate_maps"
+        expect(File.exist?(store_file)).to be false
+          
+        store_filter = setup_filter({ "code" => "map['sql_duration'] = 0", "aggregate_maps_path" => store_file })
+        expect(aggregate_maps).to be_empty
+
+        start_event = start_event("taskid" => 124)
+        filter = store_filter.filter(start_event)
+        expect(aggregate_maps.size).to eq(1)
+        
+        store_filter.close()
+        expect(File.exist?(store_file)).to be true
+        expect(aggregate_maps).to be_empty
+
+        store_filter = setup_filter({ "code" => "map['sql_duration'] = 0", "aggregate_maps_path" => store_file })
+        expect(File.exist?(store_file)).to be false
+        expect(aggregate_maps.size).to eq(1)
+        
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add new option 'aggregate_maps_path' so that aggregate maps can be stored at logstash shutdown and reloaded at logstash startup.

Fix issue #26 
