### PR TITLE
add 'aggregate_maps_path' configuration vallidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+ - bugfix: when "aggregate_maps_path" option is defined in more than one aggregate filter, raise a Logstash::ConfigurationError 
+ - bugfix: add support for logstash hot reload feature 
+
 ## 2.1.0
  - new feature: add new option "aggregate_maps_path" so that aggregate maps can be stored at logstash shutdown and reloaded at logstash startup
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,13 @@ The default value is 0, which means no timeout so no auto eviction.
 - **aggregate_maps_path:**  
 The path to file where aggregate maps are stored when logstash stops and are loaded from when logstash starts.  
 If not defined, aggregate maps will not be stored at logstash stop and will be lost.   
-Should be defined for only one aggregate filter (as aggregate maps are global).  
+Must be defined in only one aggregate filter (as aggregate maps are global).  
 Example value : `"/path/to/.aggregate_maps"`
+
+
+## Changelog
+
+Read [CHANGELOG.md](CHANGELOG.md).
 
 
 ## Need Help?

--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
-  s.version         = '2.1.0'
+  s.version         = '2.1.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = "The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task, and finally push aggregated information into final task event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -206,5 +206,16 @@ describe LogStash::Filters::Aggregate do
         
       end
     end
+
+    describe "when aggregate_maps_path option is defined in 2 instances, " do
+      it "raises Logstash::ConfigurationError" do
+
+        expect {
+          setup_filter({ "code" => "", "aggregate_maps_path" => "aggregate_maps1" })
+          setup_filter({ "code" => "", "aggregate_maps_path" => "aggregate_maps2" })
+        }.to raise_error(LogStash::ConfigurationError)
+        
+      end
+    end
   end
 end


### PR DESCRIPTION
- bugfix: when "aggregate_maps_path" option is defined in more than one aggregate filter, raise a Logstash::ConfigurationError 
- bugfix: add support for logstash hot reload feature 
