### PR TITLE
new feature: inactivity timeout

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,6 +7,7 @@ Maintainers:
 Contributors:
 * Fabien Baligand (fbaligand)
 * Artur Kronenberg (pandaadb)
+* Fernando Galandrini (fjgal)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -222,10 +222,10 @@ In that case, you don't want to wait task timeout to flush aggregation map.
 
 ==== Example #5 : no end event and push events as soon as possible
 Fifth use case: like example #3, there is no end event. Events keep comming for an indefinite time and you want to push the aggregation map as soon as possible after the last user interaction without waiting for the `timeout`. This allows to have the aggregated events pushed closer to real time.
-A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction. The user ineraction will be considered as ended when no events for the specified user (task_id) arrive afer the specified inactivity_timeout`.
-If the user continues interacting for longer than timeout seconds (since first event), the aggregation map will still be deleted and pushed as a new event when timeout occurs.
+A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction. The user ineraction will be considered as ended when no events for the specified user (task_id) arrive after the specified inactivity_timeout`.
+If the user continues interacting for longer than `timeout` seconds (since first event), the aggregation map will still be deleted and pushed as a new event when timeout occurs.
 The difference with example #3 is that the events will be pushed as soon as the user stops interacting for `inactivity_timeout` seconds instead of waiting for the end of `timeout` seconds since first event.
-In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.
+In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when inactivity timeout occurs.
 In addition, we can enable 'timeout_code' to execute code on the populated timeout event.
 We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID.
 * Given these logs:
@@ -247,7 +247,7 @@ filter {
    code => "map['clicks'] ||= 0; map['clicks'] += 1;"
    push_map_as_event_on_timeout => true
    timeout_task_id_field => "user_id"
-   timeout => 3600 # 1 hour timeout, user acivity will be considered finished one hour after the first event, even if events keep comming
+   timeout => 3600 # 1 hour timeout, user activity will be considered finished one hour after the first event, even if events keep comming
    inactivity_timeout => 300 # 5 minutes timeout, user activity will be considered finished if no new events arrive 5 minutes after the last event
    timeout_tags => ['_aggregatetimeout']
    timeout_code => "event.set('several_clicks', event.get('clicks') > 1)"

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,12 +24,12 @@ include::{include_path}/plugin_header.asciidoc[]
 The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task,
 and finally push aggregated information into final task event.
 
-You should be very careful to set Logstash filter workers to 1 (`-w 1` flag) for this filter to work correctly 
+You should be very careful to set Logstash filter workers to 1 (`-w 1` flag) for this filter to work correctly
 otherwise events may be processed out of sequence and unexpected results will occur.
 
 ==== Example #1
 
-* with these given logs :  
+* with these given logs :
 [source,ruby]
 ----------------------------------
  INFO - 12345 - TASK_START - start
@@ -45,7 +45,7 @@ otherwise events may be processed out of sequence and unexpected results will oc
    grok {
      match => [ "message", "%{LOGLEVEL:loglevel} - %{NOTSPACE:taskid} - %{NOTSPACE:logger} - %{WORD:label}( - %{INT:duration:int})?" ]
    }
- 
+
    if [logger] == "TASK_START" {
      aggregate {
        task_id => "%{taskid}"
@@ -61,7 +61,7 @@ otherwise events may be processed out of sequence and unexpected results will oc
        map_action => "update"
      }
    }
- 
+
    if [logger] == "TASK_END" {
      aggregate {
        task_id => "%{taskid}"
@@ -74,7 +74,7 @@ otherwise events may be processed out of sequence and unexpected results will oc
  }
 ----------------------------------
 
-* the final event then looks like :  
+* the final event then looks like :
 [source,ruby]
 ----------------------------------
 {
@@ -95,21 +95,21 @@ the field `sql_duration` is added and contains the sum of all sql queries durati
  INFO - 12345 - TASK_END - end
 ----------------------------------
 
-* you can also aggregate "sql duration" with a slightly different configuration : 
+* you can also aggregate "sql duration" with a slightly different configuration :
 [source,ruby]
 ----------------------------------
  filter {
    grok {
      match => [ "message", "%{LOGLEVEL:loglevel} - %{NOTSPACE:taskid} - %{NOTSPACE:logger} - %{WORD:label}( - %{INT:duration:int})?" ]
    }
-    
+
    if [logger] == "SQL" {
      aggregate {
        task_id => "%{taskid}"
        code => "map['sql_duration'] ||= 0 ; map['sql_duration'] += event.get('duration')"
      }
    }
-    
+
    if [logger] == "TASK_END" {
      aggregate {
        task_id => "%{taskid}"
@@ -127,15 +127,15 @@ the field `sql_duration` is added and contains the sum of all sql queries durati
 
 ==== Example #3 : no end event
 
-Third use case: You have no specific end event. 
+Third use case: You have no specific end event.
 
 A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction.
 
-In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.  
+In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.
 In addition, we can enable 'timeout_code' to execute code on the populated timeout event.
-We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID. 
+We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID.
 
-* Given these logs: 
+* Given these logs:
 
 [source,ruby]
 ----------------------------------
@@ -181,11 +181,11 @@ filter {
 
 ==== Example #4 : no end event and tasks come one after the other
 
-Fourth use case : like example #3, you have no specific end event, but also, tasks come one after the other.  
-That is to say : tasks are not interlaced. All task1 events come, then all task2 events come, ...  
-In that case, you don't want to wait task timeout to flush aggregation map.  
-* A typical case is aggregating results from jdbc input plugin.  
-* Given that you have this SQL query : `SELECT country_name, town_name FROM town`  
+Fourth use case : like example #3, you have no specific end event, but also, tasks come one after the other.
+That is to say : tasks are not interlaced. All task1 events come, then all task2 events come, ...
+In that case, you don't want to wait task timeout to flush aggregation map.
+* A typical case is aggregating results from jdbc input plugin.
+* Given that you have this SQL query : `SELECT country_name, town_name FROM town`
 * Using jdbc input plugin, you get these 3 events from :
 [source,json]
 ----------------------------------
@@ -220,6 +220,52 @@ In that case, you don't want to wait task timeout to flush aggregation map.
 * When 5s timeout comes, the last aggregate map is pushed as a new event
 * Finally, initial events (which are not aggregated) are dropped because useless (thanks to `event.cancel()`)
 
+==== Example #5 : no end event and push events as soon as possible
+Fifth use case: like example #3, there is no end event. Events keep comming for an indefinite time and you want to push the aggregation map as soon as possible after the last user interaction without waiting for the `timeout`. This allows to have the aggregated events pushed closer to real time.
+A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction. The user ineraction will be considered as ended when no events for the specified user (task_id) arrive afer the specified inactivity_timeout`.
+If the user continues interacting for longer than timeout seconds (since first event), the aggregation map will still be deleted and pushed as a new event when timeout occurs.
+The difference with example #3 is that the events will be pushed as soon as the user stops interacting for `inactivity_timeout` seconds instead of waiting for the end of `timeout` seconds since first event.
+In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.
+In addition, we can enable 'timeout_code' to execute code on the populated timeout event.
+We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID.
+* Given these logs:
+[source,ruby]
+----------------------------------
+INFO - 12345 - Clicked One
+INFO - 12345 - Clicked Two
+INFO - 12345 - Clicked Three
+----------------------------------
+* You can aggregate the amount of clicks the user did like this:
+[source,ruby]
+----------------------------------
+filter {
+ grok {
+   match => [ "message", "%{LOGLEVEL:loglevel} - %{NOTSPACE:user_id} - %{GREEDYDATA:msg_text}" ]
+ }
+ aggregate {
+   task_id => "%{user_id}"
+   code => "map['clicks'] ||= 0; map['clicks'] += 1;"
+   push_map_as_event_on_timeout => true
+   timeout_task_id_field => "user_id"
+   timeout => 3600 # 1 hour timeout, user acivity will be considered finished one hour after the first event, even if events keep comming
+   inactivity_timeout => 300 # 5 minutes timeout, user activity will be considered finished if no new events arrive 5 minutes after the last event
+   timeout_tags => ['_aggregatetimeout']
+   timeout_code => "event.set('several_clicks', event.get('clicks') > 1)"
+ }
+}
+----------------------------------
+* After five minutes of inactivity or one hour since first event, this will yield an event like:
+[source,json]
+----------------------------------
+{
+ "user_id": "12345",
+ "clicks": 3,
+ "several_clicks": true,
+   "tags": [
+      "_aggregatetimeout"
+   ]
+}
+----------------------------------
 
 ==== How it works
 * the filter needs a "task_id" to correlate events (log lines) of a same task
@@ -230,7 +276,7 @@ In that case, you don't want to wait task timeout to flush aggregation map.
 * an aggregate map is tied to one task_id value which is tied to one task_id pattern. So if you have 2 filters with different task_id patterns, even if you have same task_id value, they won't share the same aggregate map.
 * in one filter configuration, it is recommanded to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
 * if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted
-* all timeout options have to be defined in only one aggregate filter per task_id pattern. Timeout options are : timeout, timeout_code, push_map_as_event_on_timeout, push_previous_map_as_event, timeout_task_id_field, timeout_tags 
+* all timeout options have to be defined in only one aggregate filter per task_id pattern. Timeout options are : timeout, inactivity_timeout, timeout_code, push_map_as_event_on_timeout, push_previous_map_as_event, timeout_task_id_field, timeout_tags
 * if `code` execution raises an exception, the error is logged and event is tagged '_aggregateexception'
 
 
@@ -271,7 +317,7 @@ filter plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-aggregate_maps_path"]
-===== `aggregate_maps_path` 
+===== `aggregate_maps_path`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -279,7 +325,7 @@ filter plugins.
 The path to file where aggregate maps are stored when Logstash stops
 and are loaded from when Logstash starts.
 
-If not defined, aggregate maps will not be stored at Logstash stop and will be lost. 
+If not defined, aggregate maps will not be stored at Logstash stop and will be lost.
 Must be defined in only one aggregate filter (as aggregate maps are global).
 
 Example:
@@ -291,7 +337,7 @@ Example:
     }
 
 [id="plugins-{type}s-{plugin}-code"]
-===== `code` 
+===== `code`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -312,15 +358,15 @@ Example:
     }
 
 [id="plugins-{type}s-{plugin}-end_of_task"]
-===== `end_of_task` 
+===== `end_of_task`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-Tell the filter that task is ended, and therefore, to delete aggregate map after code execution.  
+Tell the filter that task is ended, and therefore, to delete aggregate map after code execution.
 
 [id="plugins-{type}s-{plugin}-map_action"]
-===== `map_action` 
+===== `map_action`
 
   * Value type is <<string,string>>
   * Default value is `"create_or_update"`
@@ -334,27 +380,27 @@ Tell the filter what to do with aggregate map.
 `"create_or_update"`: create the map if it wasn't created before, execute the code in all cases
 
 [id="plugins-{type}s-{plugin}-push_map_as_event_on_timeout"]
-===== `push_map_as_event_on_timeout` 
+===== `push_map_as_event_on_timeout`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-When this option is enabled, each time a task timeout is detected, it pushes task aggregation map as a new Logstash event.  
+When this option is enabled, each time a task timeout is detected, it pushes task aggregation map as a new Logstash event.
 This enables to detect and process task timeouts in Logstash, but also to manage tasks that have no explicit end event.
 
 [id="plugins-{type}s-{plugin}-push_previous_map_as_event"]
-===== `push_previous_map_as_event` 
+===== `push_previous_map_as_event`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-When this option is enabled, each time aggregate plugin detects a new task id, it pushes previous aggregate map as a new Logstash event, 
+When this option is enabled, each time aggregate plugin detects a new task id, it pushes previous aggregate map as a new Logstash event,
 and then creates a new empty map for the next task.
 
 WARNING: this option works fine only if tasks come one after the other. It means : all task1 events, then all task2 events, etc...
 
 [id="plugins-{type}s-{plugin}-task_id"]
-===== `task_id` 
+===== `task_id`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -376,7 +422,7 @@ Example:
     }
 
 [id="plugins-{type}s-{plugin}-timeout"]
-===== `timeout` 
+===== `timeout`
 
   * Value type is <<number,number>>
   * There is no default value for this setting.
@@ -390,15 +436,15 @@ Timeout can be defined for each "task_id" pattern.
 If no timeout is defined, default timeout will be applied : 1800 seconds.
 
 [id="plugins-{type}s-{plugin}-timeout_code"]
-===== `timeout_code` 
+===== `timeout_code`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-The code to execute to complete timeout generated event, when `'push_map_as_event_on_timeout'` or `'push_previous_map_as_event'` is set to true. 
-The code block will have access to the newly generated timeout event that is pre-populated with the aggregation map. 
+The code to execute to complete timeout generated event, when `'push_map_as_event_on_timeout'` or `'push_previous_map_as_event'` is set to true.
+The code block will have access to the newly generated timeout event that is pre-populated with the aggregation map.
 
-If `'timeout_task_id_field'` is set, the event is also populated with the task_id value 
+If `'timeout_task_id_field'` is set, the event is also populated with the task_id value
 
 Example:
 [source,ruby]
@@ -409,7 +455,7 @@ Example:
     }
 
 [id="plugins-{type}s-{plugin}-timeout_tags"]
-===== `timeout_tags` 
+===== `timeout_tags`
 
   * Value type is <<array,array>>
   * Default value is `[]`
@@ -425,12 +471,12 @@ Example:
     }
 
 [id="plugins-{type}s-{plugin}-timeout_task_id_field"]
-===== `timeout_task_id_field` 
+===== `timeout_task_id_field`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-This option indicates the timeout generated event's field for the "task_id" value. 
+This option indicates the timeout generated event's field for the "task_id" value.
 The task id will then be set into the timeout event. This can help correlate which tasks have been timed out.
 
 For example, with option `timeout_task_id_field => "my_id"` ,when timeout task id is `"12345"`, the generated timeout event will contain `'my_id' => '12345'`.

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -210,13 +210,13 @@ require "logstash/util/decorators"
 #
 # Fifth use case: like example #3, there is no end event. Events keep comming for an indefinite time and you want to push the aggregation map as soon as possible after the last user interaction without waiting for the `timeout`. This allows to have the aggregated events pushed closer to real time.
 #
-# A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction. The user ineraction will be considered as ended when no events for the specified user (task_id) arrive afer the specified inactivity_timeout`.
+# A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction. The user ineraction will be considered as ended when no events for the specified user (task_id) arrive after the specified inactivity_timeout`.
 #
-# If the user continues interacting for longer than timeout seconds (since first event), the aggregation map will still be deleted and pushed as a new event when timeout occurs.
+# If the user continues interacting for longer than `timeout` seconds (since first event), the aggregation map will still be deleted and pushed as a new event when timeout occurs.
 #
 # The difference with example #3 is that the events will be pushed as soon as the user stops interacting for `inactivity_timeout` seconds instead of waiting for the end of `timeout` seconds since first event.
 #
-# In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.
+# In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when inactivity timeout occurs.
 # In addition, we can enable 'timeout_code' to execute code on the populated timeout event.
 # We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID.
 #
@@ -243,7 +243,7 @@ require "logstash/util/decorators"
 #     code => "map['clicks'] ||= 0; map['clicks'] += 1;"
 #     push_map_as_event_on_timeout => true
 #     timeout_task_id_field => "user_id"
-#     timeout => 3600 # 1 hour timeout, user acivity will be considered finished one hour after the first event, even if events keep comming
+#     timeout => 3600 # 1 hour timeout, user activity will be considered finished one hour after the first event, even if events keep comming
 #     inactivity_timeout => 300 # 5 minutes timeout, user activity will be considered finished if no new events arrive 5 minutes after the last event
 #     timeout_tags => ['_aggregatetimeout']
 #     timeout_code => "event.set('several_clicks', event.get('clicks') > 1)"
@@ -679,7 +679,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
       @@flush_instance_map[@task_id].inactivity_timeout = @@flush_instance_map[@task_id].timeout
     end
 
-    # Launch timeout management only every interval of (@timeout / 2) seconds or at Logstash shutdown
+    # Launch timeout management only every interval of (@inactivity_timeout / 2) seconds or at Logstash shutdown
     if @@flush_instance_map[@task_id] == self && (!@@last_flush_timestamp_map.has_key?(@task_id) || Time.now > @@last_flush_timestamp_map[@task_id] + @inactivity_timeout / 2 || options[:final])
       events_to_flush = remove_expired_maps()
 
@@ -705,7 +705,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   end
 
 
-  # Remove the expired Aggregate maps from @@aggregate_maps if they are older than timeout or if no new event has been received seen inactivity_timeout.
+  # Remove the expired Aggregate maps from @@aggregate_maps if they are older than timeout or if no new event has been received since inactivity_timeout.
   # If @push_previous_map_as_event option is set, or @push_map_as_event_on_timeout is set, expired maps are returned as new events to be flushed to Logstash pipeline.
   def remove_expired_maps()
     events_to_flush = []

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -5,16 +5,16 @@ require "logstash/namespace"
 require "thread"
 require "logstash/util/decorators"
 
-# 
+#
 # The aim of this filter is to aggregate information available among several events (typically log lines) belonging to a same task,
 # and finally push aggregated information into final task event.
 #
-# You should be very careful to set Logstash filter workers to 1 (`-w 1` flag) for this filter to work correctly 
+# You should be very careful to set Logstash filter workers to 1 (`-w 1` flag) for this filter to work correctly
 # otherwise events may be processed out of sequence and unexpected results will occur.
-# 
+#
 # ==== Example #1
-# 
-# * with these given logs :  
+#
+# * with these given logs :
 # [source,ruby]
 # ----------------------------------
 #  INFO - 12345 - TASK_START - start
@@ -22,7 +22,7 @@ require "logstash/util/decorators"
 #  INFO - 12345 - SQL - sqlQuery2 - 34
 #  INFO - 12345 - TASK_END - end
 # ----------------------------------
-# 
+#
 # * you can aggregate "sql duration" for the whole task with this configuration :
 # [source,ruby]
 # ----------------------------------
@@ -30,7 +30,7 @@ require "logstash/util/decorators"
 #    grok {
 #      match => [ "message", "%{LOGLEVEL:loglevel} - %{NOTSPACE:taskid} - %{NOTSPACE:logger} - %{WORD:label}( - %{INT:duration:int})?" ]
 #    }
-#  
+#
 #    if [logger] == "TASK_START" {
 #      aggregate {
 #        task_id => "%{taskid}"
@@ -38,7 +38,7 @@ require "logstash/util/decorators"
 #        map_action => "create"
 #      }
 #    }
-# 
+#
 #    if [logger] == "SQL" {
 #      aggregate {
 #        task_id => "%{taskid}"
@@ -46,7 +46,7 @@ require "logstash/util/decorators"
 #        map_action => "update"
 #      }
 #    }
-#  
+#
 #    if [logger] == "TASK_END" {
 #      aggregate {
 #        task_id => "%{taskid}"
@@ -59,7 +59,7 @@ require "logstash/util/decorators"
 #  }
 # ----------------------------------
 #
-# * the final event then looks like :  
+# * the final event then looks like :
 # [source,ruby]
 # ----------------------------------
 # {
@@ -67,11 +67,11 @@ require "logstash/util/decorators"
 #   "sql_duration" => 46
 # }
 # ----------------------------------
-# 
+#
 # the field `sql_duration` is added and contains the sum of all sql queries durations.
-# 
+#
 # ==== Example #2 : no start event
-# 
+#
 # * If you have the same logs than example #1, but without a start log :
 # [source,ruby]
 # ----------------------------------
@@ -79,22 +79,22 @@ require "logstash/util/decorators"
 #  INFO - 12345 - SQL - sqlQuery2 - 34
 #  INFO - 12345 - TASK_END - end
 # ----------------------------------
-# 
-# * you can also aggregate "sql duration" with a slightly different configuration : 
+#
+# * you can also aggregate "sql duration" with a slightly different configuration :
 # [source,ruby]
 # ----------------------------------
 #  filter {
 #    grok {
 #      match => [ "message", "%{LOGLEVEL:loglevel} - %{NOTSPACE:taskid} - %{NOTSPACE:logger} - %{WORD:label}( - %{INT:duration:int})?" ]
 #    }
-#     
+#
 #    if [logger] == "SQL" {
 #      aggregate {
 #        task_id => "%{taskid}"
 #        code => "map['sql_duration'] ||= 0 ; map['sql_duration'] += event.get('duration')"
 #      }
 #    }
-#     
+#
 #    if [logger] == "TASK_END" {
 #      aggregate {
 #        task_id => "%{taskid}"
@@ -112,15 +112,15 @@ require "logstash/util/decorators"
 #
 # ==== Example #3 : no end event
 #
-# Third use case: You have no specific end event. 
+# Third use case: You have no specific end event.
 #
 # A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction.
 #
-# In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.  
+# In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.
 # In addition, we can enable 'timeout_code' to execute code on the populated timeout event.
-# We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID. 
+# We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID.
 #
-# * Given these logs: 
+# * Given these logs:
 #
 # [source,ruby]
 # ----------------------------------
@@ -130,7 +130,7 @@ require "logstash/util/decorators"
 # ----------------------------------
 #
 # * You can aggregate the amount of clicks the user did like this:
-# 
+#
 # [source,ruby]
 # ----------------------------------
 # filter {
@@ -165,12 +165,12 @@ require "logstash/util/decorators"
 # ----------------------------------
 #
 # ==== Example #4 : no end event and tasks come one after the other
-# 
-# Fourth use case : like example #3, you have no specific end event, but also, tasks come one after the other.  
-# That is to say : tasks are not interlaced. All task1 events come, then all task2 events come, ...  
-# In that case, you don't want to wait task timeout to flush aggregation map.  
-# * A typical case is aggregating results from jdbc input plugin.  
-# * Given that you have this SQL query : `SELECT country_name, town_name FROM town`  
+#
+# Fourth use case : like example #3, you have no specific end event, but also, tasks come one after the other.
+# That is to say : tasks are not interlaced. All task1 events come, then all task2 events come, ...
+# In that case, you don't want to wait task timeout to flush aggregation map.
+# * A typical case is aggregating results from jdbc input plugin.
+# * Given that you have this SQL query : `SELECT country_name, town_name FROM town`
 # * Using jdbc input plugin, you get these 3 events from :
 # [source,json]
 # ----------------------------------
@@ -204,8 +204,68 @@ require "logstash/util/decorators"
 # * The key point is that each time aggregate plugin detects a new `country_name`, it pushes previous aggregate map as a new Logstash event, and then creates a new empty map for the next country
 # * When 5s timeout comes, the last aggregate map is pushed as a new event
 # * Finally, initial events (which are not aggregated) are dropped because useless (thanks to `event.cancel()`)
-# 
-# 
+#
+#
+# ==== Example #5 : no end event and push events as soon as possible
+#
+# Fifth use case: like example #3, there is no end event. Events keep comming for an idefinite time and you want to push the aggregation map as soon as possbile after the last user interaction without waiting for the `timeout`. This allows to have the aggregated events pushed closer to real time.
+#
+# A typical case is aggregating or tracking user behaviour. We can track a user by its ID through the events, however once the user stops interacting, the events stop coming in. There is no specific event indicating the end of the user's interaction. The user ineraction will be considered as ended when no events for the specified user (task_id) arrive afer the specified inactivity_timeout`.
+#
+# If the user keeps interacting for longer than `timeout` the aggration map will be pushed at timoeout.
+#
+# The difference with example #3 is that the events will be pushed as soon as the user stops interacting for `inactivity_timeout` seconds instead of waiting for the end of `timeout seconds.`
+#
+# In this case, we can enable the option 'push_map_as_event_on_timeout' to enable pushing the aggregation map as a new event when a timeout occurs.
+# In addition, we can enable 'timeout_code' to execute code on the populated timeout event.
+# We can also add 'timeout_task_id_field' so we can correlate the task_id, which in this case would be the user's ID.
+#
+# * Given these logs:
+#
+# [source,ruby]
+# ----------------------------------
+# INFO - 12345 - Clicked One
+# INFO - 12345 - Clicked Two
+# INFO - 12345 - Clicked Three
+# ----------------------------------
+#
+# * You can aggregate the amount of clicks the user did like this:
+#
+# [source,ruby]
+# ----------------------------------
+# filter {
+#   grok {
+#     match => [ "message", "%{LOGLEVEL:loglevel} - %{NOTSPACE:user_id} - %{GREEDYDATA:msg_text}" ]
+#   }
+#
+#   aggregate {
+#     task_id => "%{user_id}"
+#     code => "map['clicks'] ||= 0; map['clicks'] += 1;"
+#     push_map_as_event_on_timeout => true
+#     timeout_task_id_field => "user_id"
+#     timeout => 3600 # 1 hour timeout, user acivity will be considered finished one hour after the first event, event if events keep comming
+#     inactivity_timeout => 300 # 5 minutes timoeout, user activity will be considered finished if no new events arrive 5 minutes after the previous event
+#     timeout_tags => ['_aggregatetimeout']
+#     timeout_code => "event.set('several_clicks', event.get('clicks') > 1)"
+#   }
+# }
+# ----------------------------------
+#
+# * After five minutes of inactivity or one hour since first event, this will yield an event like:
+#
+# [source,json]
+# ----------------------------------
+# {
+#   "user_id": "12345",
+#   "clicks": 3,
+#   "several_clicks": true,
+#     "tags": [
+#        "_aggregatetimeout"
+#     ]
+# }
+# ----------------------------------
+#
+#
 # ==== How it works
 # * the filter needs a "task_id" to correlate events (log lines) of a same task
 # * at the task beggining, filter creates a map, attached to task_id
@@ -215,7 +275,7 @@ require "logstash/util/decorators"
 # * an aggregate map is tied to one task_id value which is tied to one task_id pattern. So if you have 2 filters with different task_id patterns, even if you have same task_id value, they won't share the same aggregate map.
 # * in one filter configuration, it is recommanded to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
 # * if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted
-# * all timeout options have to be defined in only one aggregate filter per task_id pattern. Timeout options are : timeout, timeout_code, push_map_as_event_on_timeout, push_previous_map_as_event, timeout_task_id_field, timeout_tags 
+# * all timeout options have to be defined in only one aggregate filter per task_id pattern. Timeout options are : timeout, timeout_code, push_map_as_event_on_timeout, push_previous_map_as_event, timeout_task_id_field, timeout_tags
 # * if `code` execution raises an exception, the error is logged and event is tagged '_aggregateexception'
 #
 #
@@ -234,7 +294,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   # ############## #
   # CONFIG OPTIONS #
   # ############## #
-        
+
 
   config_name "aggregate"
 
@@ -275,13 +335,13 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   # `"create_or_update"`: create the map if it wasn't created before, execute the code in all cases
   config :map_action, :validate => :string, :default => "create_or_update"
 
-  # Tell the filter that task is ended, and therefore, to delete aggregate map after code execution.  
+  # Tell the filter that task is ended, and therefore, to delete aggregate map after code execution.
   config :end_of_task, :validate => :boolean, :default => false
 
   # The path to file where aggregate maps are stored when Logstash stops
   # and are loaded from when Logstash starts.
   #
-  # If not defined, aggregate maps will not be stored at Logstash stop and will be lost. 
+  # If not defined, aggregate maps will not be stored at Logstash stop and will be lost.
   # Must be defined in only one aggregate filter (as aggregate maps are global).
   #
   # Example:
@@ -292,8 +352,8 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   #       }
   #     }
   config :aggregate_maps_path, :validate => :string, :required => false
-  
-  # The amount of seconds after a task "end event" can be considered lost.
+
+  # The amount of seconds (since the first event) after a task "end event" can be considered lost.
   #
   # When timeout occurs for a task, The task "map" is evicted.
   #
@@ -302,10 +362,21 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   # If no timeout is defined, default timeout will be applied : 1800 seconds.
   config :timeout, :validate => :number, :required => false
 
-  # The code to execute to complete timeout generated event, when `'push_map_as_event_on_timeout'` or `'push_previous_map_as_event'` is set to true. 
-  # The code block will have access to the newly generated timeout event that is pre-populated with the aggregation map. 
+  # The amount of seconds (since the last event arrival) after a task "end event" can be considered lost.
   #
-  # If `'timeout_task_id_field'` is set, the event is also populated with the task_id value 
+  # When inactivity_timeout occurs for a task, The task "map" is evicted.
+  #
+  # Inactivity Timeout can be defined for each "task_id" pattern.
+  #
+  # Inactivity Timeout must be lower than `timeout`
+  #
+  # If no inactivity_timeout is defined, no inactivity timoeout will be applied (only Timeout will be applied).
+  config :inactivity_timeout, :validate => :number, :required => false
+
+  # The code to execute to complete timeout generated event, when 'push_map_as_event_on_timeout' or 'push_previous_map_as_event' is set to true.
+  # The code block will have access to the newly generated timeout event that is pre-populated with the aggregation map.
+  #
+  # If `'timeout_task_id_field'` is set, the event is also populated with the task_id value
   #
   # Example:
   # [source,ruby]
@@ -316,19 +387,19 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   #     }
   config :timeout_code, :validate => :string, :required => false
 
-  # When this option is enabled, each time a task timeout is detected, it pushes task aggregation map as a new Logstash event.  
+  # When this option is enabled, each time a task timeout is detected, it pushes task aggregation map as a new Logstash event.
   # This enables to detect and process task timeouts in Logstash, but also to manage tasks that have no explicit end event.
   config :push_map_as_event_on_timeout, :validate => :boolean, :required => false, :default => false
 
-  # When this option is enabled, each time aggregate plugin detects a new task id, it pushes previous aggregate map as a new Logstash event, 
+  # When this option is enabled, each time aggregate plugin detects a new task id, it pushes previous aggregate map as a new Logstash event,
   # and then creates a new empty map for the next task.
   #
   # WARNING: this option works fine only if tasks come one after the other. It means : all task1 events, then all task2 events, etc...
   config :push_previous_map_as_event, :validate => :boolean, :required => false, :default => false
-  
-  # This option indicates the timeout generated event's field for the "task_id" value. 
+
+  # This option indicates the timeout generated event's field for the "task_id" value.
   # The task id will then be set into the timeout event. This can help correlate which tasks have been timed out.
-  # 
+  #
   # For example, with option `timeout_task_id_field => "my_id"` ,when timeout task id is `"12345"`, the generated timeout event will contain `'my_id' => '12345'`.
   #
   # By default, if this option is not set, task id value won't be set into timeout generated event.
@@ -350,7 +421,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   # STATIC VARIABLES #
   # ################ #
 
-        
+
   # Default timeout (in seconds) when not defined in plugin configuration
   DEFAULT_TIMEOUT = 1800
 
@@ -371,29 +442,32 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   # last time where timeout management in flush() method was launched, per "task_id" pattern
   @@last_flush_timestamp_map = {}
 
+  # last time when inactivity timeout management in flush method was launched
+  @@last_flush_inactivity_timeout_timestamp = nil
+
   # flag indicating if aggregate_maps_path option has been already set on one aggregate instance
   @@aggregate_maps_path_set = false
 
   # defines which Aggregate instance will close Aggregate static variables
   @@static_close_instance = nil
-  
+
 
   # ####### #
   # METHODS #
   # ####### #
 
-        
+
   # Initialize plugin
   public
   def register
-    
+
     @logger.debug("Aggregate register call", :code => @code)
 
     # validate task_id option
     if !@task_id.match(/%\{.+\}/)
       raise LogStash::ConfigurationError, "Aggregate plugin: task_id pattern '#{@task_id}' must contain a dynamic expression like '%{field}'"
     end
-    
+
     # process lambda expression to call in each filter call
     eval("@codeblock = lambda { |event, map| #{@code} }", binding, "(aggregate filter code)")
 
@@ -401,9 +475,9 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
     if @timeout_code
       eval("@timeout_codeblock = lambda { |event| #{@timeout_code} }", binding, "(aggregate filter timeout code)")
     end
-    
+
     @@mutex.synchronize do
-      
+
       # timeout management : define eviction_instance for current task_id pattern
       if has_timeout_options?
         if @@flush_instance_map.has_key?(@task_id)
@@ -414,10 +488,15 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
         @logger.debug("Aggregate timeout for '#{@task_id}' pattern: #{@timeout} seconds")
       end
 
-      # timeout management : define default_timeout 
+      # timeout management : define default_timeout
       if !@timeout.nil? && (@@default_timeout.nil? || @timeout < @@default_timeout)
         @@default_timeout = @timeout
         @logger.debug("Aggregate default timeout: #{@timeout} seconds")
+      end
+
+      # inactivity timeout managemnet: make sure it is lower than timeout
+      if !@inactivity_timeout.nil? && ((!@timeout.nil? && @inactivity_timeout > @timeout) || (!@@default_timeout.nil? && @inactivity_timeout > @@default_timeout))
+        raise LogStash::ConfigurationError, "Aggregate plugin: For task_id pattern #{@task_id}, inactivity_timeout must be lower than timeout"
       end
 
       # reinit static_close_instance (if necessary)
@@ -435,14 +514,14 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
           @@static_close_instance = self
         end
       end
-      
+
       # load aggregate maps from file (if option defined)
       if !@aggregate_maps_path.nil? && File.exist?(@aggregate_maps_path)
         File.open(@aggregate_maps_path, "r") { |from_file| @@aggregate_maps.merge!(Marshal.load(from_file)) }
         File.delete(@aggregate_maps_path)
         @logger.info("Aggregate maps loaded from : #{@aggregate_maps_path}")
       end
-      
+
       # init aggregate_maps
       @@aggregate_maps[@task_id] ||= {}
     end
@@ -451,10 +530,10 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   # Called when Logstash stops
   public
   def close
-    
+
     @logger.debug("Aggregate close call", :code => @code)
 
-    # define static close instance if none is already defined    
+    # define static close instance if none is already defined
     @@static_close_instance = self if @@static_close_instance.nil?
 
     if @@static_close_instance == self
@@ -467,16 +546,16 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
         end
         @@aggregate_maps.clear()
       end
-  
+
       # reinit static variables for Logstash reload
       @@default_timeout = nil
       @@flush_instance_map = {}
       @@last_flush_timestamp_map = {}
       @@aggregate_maps_path_set = false
     end
-    
+
   end
-  
+
   # This method is invoked each time an event matches the filter
   public
   def filter(event)
@@ -490,10 +569,10 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 
     # protect aggregate_maps against concurrent access, using a mutex
     @@mutex.synchronize do
-    
+
       # retrieve the current aggregate map
       aggregate_maps_element = @@aggregate_maps[@task_id][task_id]
-      
+
 
       # create aggregate map, if it doesn't exist
       if aggregate_maps_element.nil?
@@ -508,24 +587,25 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
         return if @map_action == "create"
       end
       map = aggregate_maps_element.map
-
+      # update last event timestamp
+      aggregate_maps_element.lastevent_timestamp = Time.now
       # execute the code to read/update map and event
       begin
         @codeblock.call(event, map)
         @logger.debug("Aggregate successful filter code execution", :code => @code)
         noError = true
       rescue => exception
-        @logger.error("Aggregate exception occurred", 
+        @logger.error("Aggregate exception occurred",
                       :error => exception,
                       :code => @code,
                       :map => map,
                       :event_data => event.to_hash_with_metadata)
         event.tag("_aggregateexception")
       end
-      
+
       # delete the map if task is ended
       @@aggregate_maps[@task_id].delete(task_id) if @end_of_task
-      
+
     end
 
     # match the filter, only if no error occurred
@@ -544,13 +624,13 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   def create_timeout_event(aggregation_map, task_id)
 
     @logger.debug("Aggregate create_timeout_event call with task_id '#{task_id}'")
-    
-    event_to_yield = LogStash::Event.new(aggregation_map)        
+
+    event_to_yield = LogStash::Event.new(aggregation_map)
 
     if @timeout_task_id_field
       event_to_yield.set(@timeout_task_id_field, task_id)
     end
-    
+
     LogStash::Util::Decorators.add_tags(@timeout_tags, event_to_yield, "filters/#{self.class.name}")
 
     # Call code block if available
@@ -558,16 +638,16 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
       begin
         @timeout_codeblock.call(event_to_yield)
       rescue => exception
-        @logger.error("Aggregate exception occurred", 
+        @logger.error("Aggregate exception occurred",
                       :error => exception,
                       :timeout_code => @timeout_code,
                       :timeout_event_data => event_to_yield.to_hash_with_metadata)
         event_to_yield.tag("_aggregateexception")
       end
     end
-            
+
     return event_to_yield
-  end 
+  end
 
   # Extract the previous map in aggregate maps, and return it as a new Logstash event
   def extract_previous_map_as_event
@@ -581,12 +661,12 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
   def periodic_flush
     true
   end
-  
+
   # This method is invoked by LogStash every 5 seconds.
   def flush(options = {})
-    
+
     @logger.debug("Aggregate flush call with #{options}")
-      
+
     # Protection against no timeout defined by Logstash conf : define a default eviction instance with timeout = DEFAULT_TIMEOUT seconds
     if @@default_timeout.nil?
       @@default_timeout = DEFAULT_TIMEOUT
@@ -597,10 +677,17 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
     elsif @@flush_instance_map[@task_id].timeout.nil?
       @@flush_instance_map[@task_id].timeout = @@default_timeout
     end
-    
+
+    events_to_flush = []
+    # handle inactivity timeout if set and only every @inactivity_timeout / 2 seconds
+    if !@inactivity_timeout.nil? && (@@last_flush_inactivity_timeout_timestamp.nil? || Time.now > @@last_flush_inactivity_timeout_timestamp + @inactivity_timeout / 2)
+      events_to_flush = remove_inactive_maps()
+      @@last_flush_inactivity_timeout_timestamp = Time.now
+    end
+
     # Launch timeout management only every interval of (@timeout / 2) seconds or at Logstash shutdown
     if @@flush_instance_map[@task_id] == self && (!@@last_flush_timestamp_map.has_key?(@task_id) || Time.now > @@last_flush_timestamp_map[@task_id] + @timeout / 2 || options[:final])
-      events_to_flush = remove_expired_maps()
+      events_to_flush.concat remove_expired_maps()
 
       # at Logstash shutdown, if push_previous_map_as_event is enabled, it's important to force flush (particularly for jdbc input plugin)
       if options[:final] && @push_previous_map_as_event && !@@aggregate_maps[@task_id].empty?
@@ -611,30 +698,28 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
       if options[:final]
         events_to_flush.each { |event_to_flush| event_to_flush.tag("_aggregatefinalflush") }
       end
-      
+
       # update last flush timestamp
       @@last_flush_timestamp_map[@task_id] = Time.now
-        
-      # return events to flush into Logstash pipeline
-      return events_to_flush
-    else
-      return []
     end
+    # return events to flush into Logstash pipeline
+    return events_to_flush
+
 
   end
 
-  
+
   # Remove the expired Aggregate maps from @@aggregate_maps if they are older than timeout.
   # If @push_previous_map_as_event option is set, or @push_map_as_event_on_timeout is set, expired maps are returned as new events to be flushed to Logstash pipeline.
   def remove_expired_maps()
     events_to_flush = []
     min_timestamp = Time.now - @timeout
-    
+
     @@mutex.synchronize do
 
       @logger.debug("Aggregate remove_expired_maps call with '#{@task_id}' pattern and #{@@aggregate_maps[@task_id].length} maps")
 
-      @@aggregate_maps[@task_id].delete_if do |key, element| 
+      @@aggregate_maps[@task_id].delete_if do |key, element|
         if element.creation_timestamp < min_timestamp
           if @push_previous_map_as_event || @push_map_as_event_on_timeout
             events_to_flush << create_timeout_event(element.map, key)
@@ -644,11 +729,35 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
         next false
       end
     end
-    
+
     return events_to_flush
   end
-  
-  # return if this filter instance has any timeout option enabled in Logstash configuration
+
+  # Remove the expired Aggregate maps due to inactivity timeout from @@aggregate_maps if they are older than @inactivity_timeout.
+  # If @push_previous_map_as_event option is set, or @push_map_as_event_on_timeout is set, expired maps are returned as new events to be flushed to Logstash pipeline.
+  def remove_inactive_maps()
+    events_to_flush = []
+    min_timestamp = Time.now - @inactivity_timeout
+
+    @@mutex.synchronize do
+
+      @logger.debug("Aggregate remove_inactive_maps call with '#{@task_id}' pattern and #{@@aggregate_maps[@task_id].length} maps")
+
+      @@aggregate_maps[@task_id].delete_if do |key, element|
+        if element.lastevent_timestamp < min_timestamp
+          if @push_previous_map_as_event || @push_map_as_event_on_timeout
+            events_to_flush << create_timeout_event(element.map, key)
+          end
+          next true
+        end
+        next false
+      end
+    end
+
+    return events_to_flush
+  end
+
+  # return if this filter instance has any timeout option enabled in logstash configuration
   def has_timeout_options?()
     return (
       timeout ||
@@ -677,10 +786,11 @@ end # class LogStash::Filters::Aggregate
 # Element of "aggregate_maps"
 class LogStash::Filters::Aggregate::Element
 
-  attr_accessor :creation_timestamp, :map
+  attr_accessor :creation_timestamp, :lastevent_timestamp, :map
 
   def initialize(creation_timestamp)
     @creation_timestamp = creation_timestamp
+    @lastevent_timestamp = creation_timestamp
     @map = {}
   end
 end


### PR DESCRIPTION
Hi,

Thank for this great plugin!

I'm using the aggregate plugin in an application that needs to aggregate user activity and push the aggregated event to ES as soon as the user activity finishes. I had to add the concept of 'inactivity_timeout' since the existing 'timeout' concept was not enough for my application. Using the existing 'timeout' the events would be pushed to ES only once the timeout expired and reducing the timeout duration means that user interactions could not last longer than 'timeout' seconds. The new 'inactivity_timeout' is reset every time a new event for the task_id arrives, so it can be configured to a fairly low value. The timeout option can still be configured as a safety measure to make sure that aggregation maps won't be kept in memory for too long even if the user activity continues. There are no breaking changes.

I hope you find this new feature useful and accept this PR. I'd like to hear your feedback on the feature as well as the implementation.

Note: the new feature is documented in the source code but I wasn't able to automatically generate the asciidoc and README.md files

Thank you

Fernando

PS: information for CHANGELOG.md once released

```
## 2.6.0

- new feature: 'inactivity_timeout'
Events for the given task_id will be aggregated for as long as they keep arriving within the defined `inactivity_timeout` - the inactivity_timeout is reset at the arrival of each event. The `timeout` option takes precedence over it and it is not refreshed upon event arrivals.

```