### PR TITLE
correct Example 4

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -233,7 +233,7 @@ In that case, you don't want to wait task timeout to flush aggregation map.
          map['towns'] << {'town_name' => event.get('town_name')}
          event.cancel()
        "
-       push_previous_map_as_event => true
+       push_map_as_event_on_timeout => true
        timeout => 3
      }
    }


### PR DESCRIPTION
Instead of `push_map_as_event_on_timeout` should be `push_map_as_event_on_timeout`

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
