### PR TITLE
added lastevent_timestamp_rtc

### DIFF
--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -214,6 +214,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 
       # update last event timestamp
       aggregate_maps_element.lastevent_timestamp = reference_timestamp(event)
+      aggregate_maps_element.lastevent_timestamp_rtc = Time.now
 
       # execute the code to read/update map and event
       map = aggregate_maps_element.map
@@ -395,7 +396,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
       @current_pipeline.aggregate_maps[@task_id].delete_if do |key, element|
         min_timestamp = element.timeout ? Time.now - element.timeout : default_min_timestamp
         min_inactivity_timestamp = element.inactivity_timeout ? Time.now - element.inactivity_timeout : default_min_inactivity_timestamp
-        if element.creation_timestamp + element.difference_from_creation_to_now < min_timestamp || element.lastevent_timestamp + element.difference_from_creation_to_now < min_inactivity_timestamp
+        if element.creation_timestamp + element.difference_from_creation_to_now < min_timestamp || element.lastevent_timestamp_rtc < min_inactivity_timestamp
           if @push_previous_map_as_event || @push_map_as_event_on_timeout
             events_to_flush << create_timeout_event(element.map, key)
           end
@@ -500,11 +501,12 @@ end # class LogStash::Filters::Aggregate
 # Element of "aggregate_maps"
 class LogStash::Filters::Aggregate::Element
 
-  attr_accessor :creation_timestamp, :lastevent_timestamp, :difference_from_creation_to_now, :timeout, :inactivity_timeout, :task_id, :map
+  attr_accessor :creation_timestamp, :lastevent_timestamp, :lastevent_timestamp_rtc, :difference_from_creation_to_now, :timeout, :inactivity_timeout, :task_id, :map
 
   def initialize(creation_timestamp, task_id)
     @creation_timestamp = creation_timestamp
     @lastevent_timestamp = creation_timestamp
+    @lastevent_timestamp_rtc = Time.now
     @difference_from_creation_to_now = (Time.now - creation_timestamp).to_i
     @timeout = nil
     @inactivity_timeout = nil


### PR DESCRIPTION
base the remove_expired_maps check on the system clock

In the remove_expired_maps function, the inactivity_timeout would not be triggered until an additional time equal to the difference between the first and last event in the aggregate has passed. So, if you had an aggregation map that started at time=0 and the last event was at time=1000, it will wait an additional 1000 seconds past the inactivity_timeout.

This additional time should not be added. The aggregation should timeout in 'inactivity timeout' seconds after the last event is received.

To address this, the actual system time must be saved when new aggregation map events are received. That way, we can see how much actual time has passed since the last event came in.