### PR TITLE
WIP: Fix crash in pipeline environment

### DIFF
--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -124,6 +124,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
         else
           @current_pipeline.aggregate_maps_path_set = true
           @current_pipeline.pipeline_close_instance = self
+          @aggregate_maps_path=@aggregate_maps_path+"_"+execution_context.pipeline.pipeline_id
         end
       end
 


### PR DESCRIPTION
Hi

I am trying to save the maps of aggregate in a logstash filter that uses 8 pipelines.
But the plugin crashes with the following exception:
`[2021-06-18T10:32:25,956][ERROR][logstash.javapipeline    ][smtp11] Pipeline error {:pipeline_id=>"smtp11", :exception=>#<TypeError: nil is not a string>, 
:backtrace=>["org/jruby/RubyMarshal.java:138:in `load'", "/opt/logstash-7.10.2/vendor/bundle/jruby/2.5.0/gems/logstash-filter-aggregate-2.9.2/lib/logstash/filters/aggregate.rb:132:in 
`block in register'", "org/jruby/RubyIO.java:1158:in `open'", "/opt/logstash-7.10.2/vendor/bundle/jruby/2.5.0/gems/logstash-filter-aggregate-2.9.2/lib/logstash/filters/aggregate.rb:132:in
`block in register'", "org/jruby/ext/thread/Mutex.java:164:in `synchronize'", "/opt/logstash-7.10.2/vendor/bundle/jruby/2.5.0/gems/logstash-filter-aggregate-2.9.2/lib/logstash/filters/aggregate.rb:97:in
`register'", "org/logstash/config/ir/compiler/AbstractFilterDelegatorExt.java:75:in `register'", "/opt/logstash-7.10.2/logstash-core/lib/logstash/java_pipeline.rb:228:in
`block in register_plugins'", "org/jruby/RubyArray.java:1809:in `each'", "/opt/logstash-7.10.2/logstash-core/lib/logstash/java_pipeline.rb:227:in `register_plugins'", 
"/opt/logstash-7.10.2/logstash-core/lib/logstash/java_pipeline.rb:586:in `maybe_setup_out_plugins'", "/opt/logstash-7.10.2/logstash-core/lib/logstash/java_pipeline.rb:240:in 
`start_workers'", "/opt/logstash-7.10.2/logstash-core/lib/logstash/java_pipeline.rb:185:in `run'", "/opt/logstash-7.10.2/logstash-core/lib/logstash/java_pipeline.rb:137:in 
`block in start'"], "pipeline.sources"=>[...],
:thread=>"#<Thread:0x153f3631 run>"}`
(See Elastic Case: https://support.elastic.co/customers/s/case/5004M00000i7jHN)

Attaching the pipeline ID prevents this crash.

My prefered solution would be to add a flag defaulting to true only if more than one pipeline is used, but I have no clue how to do this.

Regards
Patrick