### PR TITLE
Added support for new event generation in ruby code

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -402,7 +402,7 @@ The code to execute to update aggregated map, using current event.
 
 Or on the contrary, the code to execute to update event, using aggregated map.
 
-Available variables are :
+Available variables are:
 
 `event`: current Logstash event
 
@@ -411,8 +411,6 @@ Available variables are :
 `map_meta`: meta informations associated to aggregate map. It allows to set a custom `timeout` or `inactivity_timeout`. 
 It allows also to get `creation_timestamp`, `lastevent_timestamp` and `task_id`.
 
-When option push_map_as_event_on_timeout=true, if you set `map_meta.timeout=0` in `code` block, then aggregated map is immediately pushed as a new event.
-
 Example:
 [source,ruby]
     filter {
@@ -420,6 +418,29 @@ Example:
         code => "map['sql_duration'] += event.get('duration')"
       }
     }
+
+
+To create additional events during the code block, to be emitted immediatly, a specific syntax must be used, like in the following example:
+
+[source,ruby]
+    filter {
+      aggregate {
+        code => "
+            data = {:my_sql_duration => map['sql_duration']}
+            generated_event = LogStash::Event.new(data)
+            generated_event.set('my_other_field', 34)
+            new_event_block.call(generated_event)
+        "
+      }
+    }
+
+The parameter to the function `new_event_block.call` must be of type `LogStash::Event`.
+To creare such object the costructor of the same class can be used, like `LogStash::Event.new()`.
+
+`LogStash::Event.new()` can receive a parameter of type ruby `Hash` to inizialize the new event fields.
+
+When option push_map_as_event_on_timeout=true, if you set `map_meta.timeout=0` in `code` block, then aggregated map is immediately pushed as a new event.
+
 
 [id="plugins-{type}s-{plugin}-end_of_task"]
 ===== `end_of_task`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -411,6 +411,11 @@ Available variables are:
 `map_meta`: meta informations associated to aggregate map. It allows to set a custom `timeout` or `inactivity_timeout`. 
 It allows also to get `creation_timestamp`, `lastevent_timestamp` and `task_id`.
 
+`new_event_block`: ruby block used to create new Logstash events. See the following example on how to use it.
+
+When option push_map_as_event_on_timeout=true, if you set `map_meta.timeout=0` in `code` block, then aggregated map is immediately pushed as a new event.
+
+
 Example:
 [source,ruby]
     filter {
@@ -420,7 +425,7 @@ Example:
     }
 
 
-To create additional events during the code block, to be emitted immediatly, a specific syntax must be used, like in the following example:
+To create additional events during the code block, to be emitted immediately, a specific syntax must be used, like in the following example:
 
 [source,ruby]
     filter {
@@ -435,11 +440,9 @@ To create additional events during the code block, to be emitted immediatly, a s
     }
 
 The parameter to the function `new_event_block.call` must be of type `LogStash::Event`.
-To creare such object the costructor of the same class can be used, like `LogStash::Event.new()`.
+To create such object the constructor of the same class can be used, like `LogStash::Event.new()`.
 
-`LogStash::Event.new()` can receive a parameter of type ruby `Hash` to inizialize the new event fields.
-
-When option push_map_as_event_on_timeout=true, if you set `map_meta.timeout=0` in `code` block, then aggregated map is immediately pushed as a new event.
+`LogStash::Event.new()` can receive a parameter of type ruby http://ruby-doc.org/core-1.9.1/Hash.html[Hash] to initialize the new event fields.
 
 
 [id="plugins-{type}s-{plugin}-end_of_task"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -411,7 +411,7 @@ Available variables are:
 `map_meta`: meta informations associated to aggregate map. It allows to set a custom `timeout` or `inactivity_timeout`. 
 It allows also to get `creation_timestamp`, `lastevent_timestamp` and `task_id`.
 
-`new_event_block`: ruby block used to create new Logstash events. See the following example on how to use it.
+`new_event_block`: block used to emit new Logstash events. See the second example on how to use it.
 
 When option push_map_as_event_on_timeout=true, if you set `map_meta.timeout=0` in `code` block, then aggregated map is immediately pushed as a new event.
 
@@ -425,7 +425,7 @@ Example:
     }
 
 
-To create additional events during the code block, to be emitted immediately, a specific syntax must be used, like in the following example:
+To create additional events during the code execution, to be emitted immediately, you can use `new_event_block.call(event)` function, like in the following example:
 
 [source,ruby]
     filter {
@@ -439,9 +439,8 @@ To create additional events during the code block, to be emitted immediately, a 
       }
     }
 
-The parameter to the function `new_event_block.call` must be of type `LogStash::Event`.
-To create such object the constructor of the same class can be used, like `LogStash::Event.new()`.
-
+The parameter of the function `new_event_block.call` must be of type `LogStash::Event`.  
+To create such an object, the constructor of the same class can be used: `LogStash::Event.new()`.  
 `LogStash::Event.new()` can receive a parameter of type ruby http://ruby-doc.org/core-1.9.1/Hash.html[Hash] to initialize the new event fields.
 
 

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -83,7 +83,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
     end
 
     # process lambda expression to call in each filter call
-    eval("@codeblock = lambda { |event, map, map_meta| #{@code} }", binding, "(aggregate filter code)")
+    eval("@codeblock = lambda { |event, map, map_meta, &new_event_block| #{@code} }", binding, "(aggregate filter code)")
 
     # process lambda expression to call in the timeout case or previous event case
     if @timeout_code
@@ -168,7 +168,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 
   # This method is invoked each time an event matches the filter
   public
-  def filter(event)
+  def filter(event, &new_event_block)
 
     # define task id
     task_id = event.sprintf(@task_id)
@@ -213,7 +213,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
       # execute the code to read/update map and event
       map = aggregate_maps_element.map
       begin
-        @codeblock.call(event, map, aggregate_maps_element)
+        @codeblock.call(event, map, aggregate_maps_element, &new_event_block)
         @logger.debug("Aggregate successful filter code execution", :code => @code)
         noError = true
       rescue => exception

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -420,4 +420,17 @@ describe LogStash::Filters::Aggregate do
     end
   end
 
+  context "Custom event generation code is used" do
+    describe "when a new event is manually generated" do
+      it "should push a new event immediately" do
+        agg_filter = setup_filter({ "task_id" => "%{task_id}", "code" => "map['sql_duration'] = 2; new_event_block.call(LogStash::Event.new({:my_sql_duration => map['sql_duration']}))", "timeout" => 120 })
+        agg_filter.filter(event({"task_id" => "1"})) do |yield_event|
+          expect(yield_event).not_to be_nil
+          expect(yield_event.get("my_sql_duration")).to eq(2)
+        end
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Hello,
This PR adds support for new event generation in the ruby code executed for every event processed by the aggregate plugin.
It uses the same logic as the `ruby` filter plugin.