### PR TITLE
Add warning log when the number of tasks stored in memory exceeds the configured threshold.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 2.10.1
-  - new feature: add warning log when the number of tasks stored in memory exceeds the configured threshold (#125)
+## 2.11.0
+  - new feature: log a warning message when the number of tasks stored in memory exceeds the configured threshold (#125)
 
 ## 2.10.0
   - new feature: add ability to generate new event during code execution (#116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.10.1
+  - new feature: add warning log when the number of tasks stored in memory exceeds the configured threshold (#125)
+
 ## 2.10.0
   - new feature: add ability to generate new event during code execution (#116)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -364,6 +364,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-timeout_tags>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-timeout_task_id_field>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-timeout_timestamp_field>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-map_count_warning_threshold>> |<<number,number>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -611,6 +612,29 @@ Example:
     filter {
       aggregate {
         timeout_timestamp_field => "@timestamp"
+      }
+    }
+
+[id="plugins-{type}s-{plugin}-map_count_warning_threshold"]
+===== `map_count_warning_threshold`
+
+  * Value type is <<number,number>>
+  * Default value is `5000`
+
+Defines the threshold for the number of tasks in memory before a warning is logged.
+When the number of maps for a task_id pattern exceeds this threshold, a warning message is logged to help identify potential memory issues caused by unterminated tasks.
+
+The warning is repeated every 20% of the threshold events (e.g., with threshold 5000, warnings appear every 1000 events while above threshold).
+
+Set to `0` to disable memory warnings.
+
+Example:
+[source,ruby]
+    filter {
+      aggregate {
+        task_id => "%{taskid}"
+        code => "map['count'] ||= 0; map['count'] += 1"
+        map_count_warning_threshold => 10000
       }
     }
 

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -42,6 +42,10 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 
   config :timeout_tags, :validate => :array, :required => false, :default => []
 
+  config :map_count_warning_threshold, :validate => :number, :required => false, :default => 5000
+
+  config :map_count_warning_interval, :validate => :number, :required => false, :default => 1000
+
 
   # ################## #
   # INSTANCE VARIABLES #
@@ -179,6 +183,9 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 
     # protect aggregate_maps against concurrent access, using a mutex
     @current_pipeline.mutex.synchronize do
+
+      # check for memory warning
+      check_map_count_warning()
 
       # if timeout is based on event timestamp, check if task_id map is expired and should be removed
       if @timeout_timestamp_field
@@ -483,6 +490,27 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
     if aggregate_maps
       metric.gauge(:aggregate_maps, aggregate_maps.length)
     end
+  end
+
+  # checks if map count exceeds warning threshold and logs a warning if so
+  def check_map_count_warning()
+    return if @map_count_warning_threshold == 0
+
+    map_count = @current_pipeline.aggregate_maps[@task_id].length
+    if map_count >= @map_count_warning_threshold
+      @events_since_last_warning ||= 0
+      if @events_since_last_warning == 0
+        @logger.warn("Aggregate filter memory warning: task_id pattern '#{@task_id}' has #{map_count} maps in memory (threshold: #{@map_count_warning_threshold}).",
+                     :task_id_pattern => @task_id,
+                     :map_count => map_count,
+                     :threshold => @map_count_warning_threshold)
+      end
+      # repeat warning every @map_count_warning_interval events
+      @events_since_last_warning = (@events_since_last_warning + 1) % @map_count_warning_interval
+    else
+      @events_since_last_warning = 0
+    end
+
   end
 
 end # class LogStash::Filters::Aggregate

--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
-  s.version = '2.10.1'
+  s.version = '2.11.0'
   s.licenses = ['Apache-2.0']
   s.summary = 'Aggregates information from several events originating with a single task'
   s.description = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'

--- a/logstash-filter-aggregate.gemspec
+++ b/logstash-filter-aggregate.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-aggregate'
-  s.version = '2.10.0'
+  s.version = '2.10.1'
   s.licenses = ['Apache-2.0']
   s.summary = 'Aggregates information from several events originating with a single task'
   s.description = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -452,18 +452,17 @@ describe LogStash::Filters::Aggregate do
         4.times { |i| filter.filter(event({"warn_id" => "task_#{i}"})) }
       end
 
-      it "should log warning every map_count_warning_interval occurrences" do
-        filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "", "map_count_warning_threshold" => 3, "map_count_warning_interval" => 2 })
+      it "should log warning every 20% of map_count_warning_threshold occurrences" do
+        filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "", "map_count_warning_threshold" => 5 })
         expect(filter.logger).to receive(:warn).twice
-        6.times { |i| filter.filter(event({"warn_id" => "task_#{i}"})) }
+        7.times { |i| filter.filter(event({"warn_id" => "task_#{i}"})) }
       end
     end
 
     describe "when using default threshold" do
-      it "should have default threshold of 5000 and default warning interval of 1000" do
+      it "should have default threshold of 5000" do
         filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "" })
         expect(filter.map_count_warning_threshold).to eq(5000)
-        expect(filter.map_count_warning_interval).to eq(1000)
       end
     end
   end

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -433,4 +433,38 @@ describe LogStash::Filters::Aggregate do
 
   end
 
+  context "map_count_warning_threshold option" do
+    describe "when threshold is set to 0 (disabled)" do
+      it "should not log any warning" do
+        filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "", "map_count_warning_threshold" => 0 })
+        expect(filter.logger).not_to receive(:warn)
+        3.times { |i| filter.filter(event({"warn_id" => "task_#{i}"})) }
+      end
+    end
+
+    describe "when map count reaches threshold" do
+      it "should log a warning" do
+        filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "", "map_count_warning_threshold" => 3 })
+        expect(filter.logger).to receive(:warn).with(
+          /Aggregate filter memory warning.*has 3 maps in memory/,
+          hash_including(:task_id_pattern => "%{warn_id}", :map_count => 3, :threshold => 3)
+        ).once
+        4.times { |i| filter.filter(event({"warn_id" => "task_#{i}"})) }
+      end
+
+      it "should log warning every map_count_warning_interval occurrences" do
+        filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "", "map_count_warning_threshold" => 3, "map_count_warning_interval" => 2 })
+        expect(filter.logger).to receive(:warn).twice
+        6.times { |i| filter.filter(event({"warn_id" => "task_#{i}"})) }
+      end
+    end
+
+    describe "when using default threshold" do
+      it "should have default threshold of 5000 and default warning interval of 1000" do
+        filter = setup_filter({ "task_id" => "%{warn_id}", "code" => "" })
+        expect(filter.map_count_warning_threshold).to eq(5000)
+        expect(filter.map_count_warning_interval).to eq(1000)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces a new feature to log a warning when the number of tasks stored in memory exceeds the configured threshold.

Two new config parameters have been added:
 - `map_count_warning_threshold`: The max number of tasks that can be stored in memory simultaneously before warning. The warning message will be repeated every 20% of the configured threshold.
 
Added Unit tests and also tested manually with following config:

```
input {
  generator {
    count => 10
    message => "test event"
  }
}

filter {
  ruby {
    code => "event.set('task_id', java.util.UUID.randomUUID.to_s)"
  }

  # Aggregate filter with low threshold for testing
  aggregate {
    task_id => "%{task_id}"
    code => ""
    # No end_of_task - maps accumulate forever
    map_count_warning_threshold => 5
    timeout => 3600
  }
}

output {
  stdout {
    codec => dots
  }
}
```
 The config generates 50 task events, configuring threshold to 5 and repeating the log after every 20% of 5 (1). This should generate 5 warning logs, one every 5 events after first 5 tasks:
 
```
[2026-02-03T16:12:45,527][WARN ][logstash.filters.aggregate][main][9f2d3e17a6b9686b2905ba0fa1916354a354f5c8847f1717f279cca7dadcd94d] Aggregate filter memory warning: task_id pattern '%{task_id}' has 5 maps in memory (threshold: 5). {:task_id_pattern=>"%{task_id}", :map_count=>5, :threshold=>5}
[2026-02-03T16:12:45,527][WARN ][logstash.filters.aggregate][main][9f2d3e17a6b9686b2905ba0fa1916354a354f5c8847f1717f279cca7dadcd94d] Aggregate filter memory warning: task_id pattern '%{task_id}' has 6 maps in memory (threshold: 5). {:task_id_pattern=>"%{task_id}", :map_count=>6, :threshold=>5}
[2026-02-03T16:12:45,528][WARN ][logstash.filters.aggregate][main][9f2d3e17a6b9686b2905ba0fa1916354a354f5c8847f1717f279cca7dadcd94d] Aggregate filter memory warning: task_id pattern '%{task_id}' has 7 maps in memory (threshold: 5). {:task_id_pattern=>"%{task_id}", :map_count=>7, :threshold=>5}
[2026-02-03T16:12:45,528][WARN ][logstash.filters.aggregate][main][9f2d3e17a6b9686b2905ba0fa1916354a354f5c8847f1717f279cca7dadcd94d] Aggregate filter memory warning: task_id pattern '%{task_id}' has 8 maps in memory (threshold: 5). {:task_id_pattern=>"%{task_id}", :map_count=>8, :threshold=>5}
[2026-02-03T16:12:45,528][WARN ][logstash.filters.aggregate][main][9f2d3e17a6b9686b2905ba0fa1916354a354f5c8847f1717f279cca7dadcd94d] Aggregate filter memory warning: task_id pattern '%{task_id}' has 9 maps in memory (threshold: 5). {:task_id_pattern=>"%{task_id}", :map_count=>9, :threshold=>5}
```
Tested with bigger thresholds as well.
