### PR TITLE
docs: fix typo 'Developement' -> 'Development' in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,7 +13,7 @@ Logstash provides infrastructure to automatically generate documentation for thi
 
 ## Developing
 
-### 1. Plugin Developement and Testing
+### 1. Plugin Development and Testing
 
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.


### PR DESCRIPTION
This PR fixes a simple documentation typo:  →  in BUILD.md.

No functional changes, just a small documentation fix.

## Summary
- Fixes a single documentation spelling error
- 1 file +1/-1 change