### PR TITLE
docs: fix two spelling typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/log
 
 ## Developing
 
-### 1. Plugin Developement and Testing
+### 1. Plugin Development and Testing
 
 #### Code
 - To get started, you'll need JRuby with the Bundler gem installed.

--- a/spec/filters/aggregate_spec.rb
+++ b/spec/filters/aggregate_spec.rb
@@ -356,7 +356,7 @@ describe LogStash::Filters::Aggregate do
     end
 
     describe "when Logstash shutdown happens, " do
-      it "flush method should return last map as new event even if timeout has not occured" do
+      it "flush method should return last map as new event even if timeout has not occurred" do
         push_filter = setup_filter({ "task_id" => "%{ppm_id}", "code" => "", "push_previous_map_as_event" => true, "timeout" => 4 })
         push_filter.filter(event({"ppm_id" => "1"}))
         events_to_flush = push_filter.flush({:final=>false})


### PR DESCRIPTION
## Summary

Fixes two spelling typos:
1.  →  in README.md
2.  →  in aggregate_spec.rb

Both are simple documentation/test comment typos, no functional changes.

Please review 🙏